### PR TITLE
ci: Enable Asset Library action

### DIFF
--- a/.github/workflows/godot-asset-library.yaml
+++ b/.github/workflows/godot-asset-library.yaml
@@ -7,8 +7,6 @@ name: Push to Godot Asset Library
 
 jobs:
   publish:
-    # TODO: Add assetId below, then enable
-    if: false
     runs-on: ubuntu-latest
     name: Push new release
     steps:
@@ -19,5 +17,5 @@ jobs:
         with:
           username: ${{ secrets.GODOT_ASSET_LIBRARY_USERNAME }}
           password: ${{ secrets.GODOT_ASSET_LIBRARY_PASSWORD }}
-          assetId: TODO
+          assetId: 4391
           assetTemplate: asset-template.json.hb


### PR DESCRIPTION
The asset is now published at
https://godotengine.org/asset-library/asset/4391.

Add this asset ID to the workflow and enable it.

https://github.com/endlessm/godot-sprite-frames-exported-textures/issues/9